### PR TITLE
confusing typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The parameter `options` consists of the following properties:
 - **Usage**: The name of the action.
 ```js
 {
-  method: "getPosts"
+  action: "getPosts"
 }
 ```
 


### PR DESCRIPTION
The `action` section had an example that incorrectly used `method` as the object key.